### PR TITLE
[codex] Improve Discord bridge channel bootstrap and recovery

### DIFF
--- a/agent/tests/test_discord_bridge.py
+++ b/agent/tests/test_discord_bridge.py
@@ -1,5 +1,6 @@
 """Tests for Discord bridge (Phase 5 PoC)."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -78,6 +79,52 @@ class TestDiscordBridgePoC:
         assert mock_thread.send.called
 
     @pytest.mark.anyio
+    async def test_on_output_restores_thread_id_from_persisted_session(
+        self, fresh_store: SessionStore
+    ) -> None:
+        """Persisted thread bindings should recover after bridge state drift."""
+        from tether.bridges.discord.bot import DiscordBridge
+
+        session = fresh_store.create_session("repo_test", "main")
+        session.platform = "discord"
+        session.platform_thread_id = "9876543210"
+        fresh_store.update_session(session)
+
+        mock_client = MagicMock()
+        mock_thread = AsyncMock()
+        mock_client.get_channel.return_value = mock_thread
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=1234567890,
+        )
+        bridge._client = mock_client
+
+        await bridge.on_output(session.id, "Recovered Discord output")
+
+        assert bridge._thread_ids[session.id] == 9876543210
+        assert mock_thread.send.called
+
+    def test_session_for_thread_restores_mapping_from_store(
+        self, fresh_store: SessionStore
+    ) -> None:
+        """Inbound thread replies should still resolve after restart."""
+        from tether.bridges.discord.bot import DiscordBridge
+
+        session = fresh_store.create_session("repo_test", "main")
+        session.platform = "discord"
+        session.platform_thread_id = "9876543210"
+        fresh_store.update_session(session)
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=1234567890,
+        )
+
+        assert bridge._session_for_thread(9876543210) == session.id
+        assert bridge._thread_ids[session.id] == 9876543210
+
+    @pytest.mark.anyio
     async def test_create_thread_creates_discord_thread(
         self, fresh_store: SessionStore
     ) -> None:
@@ -89,9 +136,11 @@ class TestDiscordBridgePoC:
         # Mock Discord client
         mock_client = MagicMock()
         mock_channel = AsyncMock()
+        mock_starter_message = AsyncMock()
         mock_thread = MagicMock()
         mock_thread.id = 9876543210
-        mock_channel.create_thread.return_value = mock_thread
+        mock_starter_message.create_thread.return_value = mock_thread
+        mock_channel.send.return_value = mock_starter_message
         mock_client.get_channel.return_value = mock_channel
 
         bridge = DiscordBridge(
@@ -103,10 +152,156 @@ class TestDiscordBridgePoC:
         # Create thread
         result = await bridge.create_thread(session.id, "Test Session")
 
-        # Verify thread was created
-        assert mock_channel.create_thread.called
+        # Verify a visible thread was created from a starter message
+        assert mock_channel.send.called
+        assert mock_starter_message.create_thread.called
         assert result["thread_id"] == "9876543210"
         assert result["platform"] == "discord"
+
+    @pytest.mark.anyio
+    async def test_create_thread_fetches_preconfigured_channel_when_cache_empty(
+        self, fresh_store: SessionStore
+    ) -> None:
+        """Preconfigured control channels do not rely on Discord cache warmup."""
+        from tether.bridges.discord.bot import DiscordBridge
+
+        session = fresh_store.create_session("repo_test", "main")
+
+        mock_client = MagicMock()
+        fetched_channel = AsyncMock()
+        fetched_channel.id = 1234567890
+        mock_starter_message = AsyncMock()
+        mock_thread = MagicMock()
+        mock_thread.id = 222333444
+        mock_starter_message.create_thread.return_value = mock_thread
+        fetched_channel.send.return_value = mock_starter_message
+        mock_client.get_channel.return_value = None
+        mock_client.fetch_channel = AsyncMock(return_value=fetched_channel)
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=1234567890,
+        )
+        bridge._client = mock_client
+
+        result = await bridge.create_thread(session.id, "Fetched Channel Session")
+
+        mock_client.fetch_channel.assert_awaited_once_with(1234567890)
+        fetched_channel.send.assert_awaited_once()
+        mock_starter_message.create_thread.assert_awaited_once()
+        assert result["thread_id"] == "222333444"
+        assert result["platform"] == "discord"
+
+    @pytest.mark.anyio
+    async def test_auto_control_channel_reuses_existing_hostname_channel(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
+        from agent_tether.base import BridgeConfig
+
+        monkeypatch.setattr("tether.bridges.discord.bot.socket.gethostname", lambda: "box4080")
+
+        mock_client = MagicMock()
+        existing_channel = MagicMock()
+        existing_channel.id = 555
+        existing_channel.name = "🤖-box4080"
+        mock_guild = MagicMock()
+        mock_guild.id = 123456
+        mock_guild.text_channels = [existing_channel]
+        mock_client.get_guild.return_value = mock_guild
+        mock_client.guilds = [mock_guild]
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=0,
+            discord_config=DiscordConfig(guild_id=123456),
+            config=BridgeConfig(data_dir=str(tmp_path)),
+        )
+        bridge._client = mock_client
+
+        channel = await bridge._ensure_control_channel()
+
+        assert channel is existing_channel
+        assert bridge._channel_id == 555
+        assert not mock_guild.create_text_channel.called
+
+    @pytest.mark.anyio
+    async def test_auto_control_channel_creates_missing_hostname_channel(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
+        from agent_tether.base import BridgeConfig
+
+        monkeypatch.setattr("tether.bridges.discord.bot.socket.gethostname", lambda: "kali14")
+
+        mock_client = MagicMock()
+        created_channel = MagicMock()
+        created_channel.id = 777
+        created_channel.name = "🤖-kali14"
+        mock_guild = MagicMock()
+        mock_guild.id = 654321
+        mock_guild.text_channels = []
+        mock_guild.create_text_channel = AsyncMock(return_value=created_channel)
+        mock_client.get_guild.return_value = mock_guild
+        mock_client.guilds = [mock_guild]
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=0,
+            discord_config=DiscordConfig(guild_id=654321),
+            config=BridgeConfig(data_dir=str(tmp_path)),
+        )
+        bridge._client = mock_client
+
+        channel = await bridge._ensure_control_channel()
+
+        assert channel is created_channel
+        assert bridge._channel_id == 777
+        mock_guild.create_text_channel.assert_awaited_once()
+        assert mock_guild.create_text_channel.await_args.kwargs["name"] == "🤖-kali14"
+
+    @pytest.mark.anyio
+    async def test_create_thread_bootstraps_control_channel_when_unset(
+        self, fresh_store: SessionStore, monkeypatch, tmp_path
+    ) -> None:
+        from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
+        from agent_tether.base import BridgeConfig
+
+        monkeypatch.setattr("tether.bridges.discord.bot.socket.gethostname", lambda: "thinkpad1")
+
+        session = fresh_store.create_session("repo_test", "main")
+
+        control_channel = AsyncMock()
+        control_channel.id = 1001
+        control_channel.name = "🤖-thinkpad1"
+        starter_message = AsyncMock()
+        thread = MagicMock()
+        thread.id = 2002
+        starter_message.create_thread.return_value = thread
+        control_channel.send.return_value = starter_message
+
+        mock_guild = MagicMock()
+        mock_guild.id = 8080
+        mock_guild.text_channels = [control_channel]
+
+        mock_client = MagicMock()
+        mock_client.get_guild.return_value = mock_guild
+        mock_client.guilds = [mock_guild]
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=0,
+            discord_config=DiscordConfig(guild_id=8080),
+            config=BridgeConfig(data_dir=str(tmp_path)),
+        )
+        bridge._client = mock_client
+
+        result = await bridge.create_thread(session.id, "Test Session")
+
+        assert bridge._channel_id == 1001
+        control_channel.send.assert_awaited_once()
+        starter_message.create_thread.assert_awaited_once()
+        assert result["thread_id"] == "2002"
 
     @pytest.mark.anyio
     async def test_thread_names_are_unique_like_telegram(
@@ -118,9 +313,11 @@ class TestDiscordBridgePoC:
         # Mock Discord client
         mock_client = MagicMock()
         mock_channel = AsyncMock()
+        mock_starter_message = AsyncMock()
         mock_thread = MagicMock()
         mock_thread.id = 111
-        mock_channel.create_thread.return_value = mock_thread
+        mock_starter_message.create_thread.return_value = mock_thread
+        mock_channel.send.return_value = mock_starter_message
         mock_client.get_channel.return_value = mock_channel
 
         bridge = DiscordBridge(
@@ -130,18 +327,52 @@ class TestDiscordBridgePoC:
         )
         bridge._client = mock_client
 
-        name1 = bridge._make_external_thread_name(directory="/repo", session_id="sess_1")
+        name1 = bridge._make_external_thread_name(
+            directory="/repo", session_id="sess_1"
+        )
         await bridge.create_thread("sess_1", name1)
 
         mock_thread_2 = MagicMock()
         mock_thread_2.id = 222
-        mock_channel.create_thread.return_value = mock_thread_2
+        mock_starter_message_2 = AsyncMock()
+        mock_starter_message_2.create_thread.return_value = mock_thread_2
+        mock_channel.send.return_value = mock_starter_message_2
 
-        name2 = bridge._make_external_thread_name(directory="/repo", session_id="sess_2")
+        name2 = bridge._make_external_thread_name(
+            directory="/repo", session_id="sess_2"
+        )
         await bridge.create_thread("sess_2", name2)
 
         assert name1 == "Repo"
         assert name2 == "Repo 2"
+
+    @pytest.mark.anyio
+    async def test_create_thread_falls_back_for_non_text_channels(
+        self, fresh_store: SessionStore
+    ) -> None:
+        """Non-text Discord channels still use the upstream thread creation path."""
+        from tether.bridges.discord.bot import DiscordBridge
+
+        session = fresh_store.create_session("repo_test", "main")
+
+        mock_client = MagicMock()
+        mock_channel = object()
+        mock_client.get_channel.return_value = mock_channel
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=1234567890,
+        )
+        bridge._client = mock_client
+
+        with patch(
+            "agent_tether.discord.bot.DiscordBridge.create_thread",
+            new=AsyncMock(return_value={"thread_id": "321", "platform": "discord"}),
+        ) as create_thread:
+            result = await bridge.create_thread(session.id, "Fallback Session")
+
+        assert create_thread.await_count == 1
+        assert result["thread_id"] == "321"
 
     @pytest.mark.anyio
     async def test_on_status_change_sends_to_discord(
@@ -461,6 +692,40 @@ class TestDiscordBridgePoC:
         callbacks.list_sessions.assert_called_once()
 
     @pytest.mark.anyio
+    async def test_auto_pair_user_ids_authorize_commands(
+        self, tmp_path
+    ) -> None:
+        from agent_tether.base import BridgeConfig
+        from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
+
+        callbacks = _mock_callbacks()
+        bridge = DiscordBridge(
+            bot_token="x",
+            channel_id=1234567890,
+            discord_config=DiscordConfig(
+                require_pairing=True,
+                auto_pair_user_ids=[222],
+            ),
+            callbacks=callbacks,
+            config=BridgeConfig(data_dir=str(tmp_path)),
+        )
+
+        mock_channel = AsyncMock()
+        mock_channel.id = 1234567890
+        mock_message = MagicMock()
+        mock_message.channel = mock_channel
+        mock_message.guild = MagicMock()
+        mock_message.author.id = 222
+        mock_message.author.name = "testuser"
+
+        await bridge._dispatch_command(mock_message, "!status")
+
+        assert 222 in bridge._paired_user_ids
+        callbacks.list_sessions.assert_called_once()
+        pairing_payload = json.loads((tmp_path / "discord_pairing.json").read_text("utf-8"))
+        assert pairing_payload["paired_user_ids"] == [222]
+
+    @pytest.mark.anyio
     async def test_setup_command_sets_control_channel_and_pairs_user(
         self, fresh_store: SessionStore, monkeypatch
     ) -> None:
@@ -518,9 +783,10 @@ class TestDiscordBridgePoC:
         # Stop typing indicator
         await bridge.on_typing_stopped(session.id)
         assert session.id not in bridge._typing_tasks
-        
+
         # Give the task a moment to cancel
         import asyncio
+
         await asyncio.sleep(0.01)
         assert typing_task.cancelled() or typing_task.done()
 

--- a/agent/tests/test_settings.py
+++ b/agent/tests/test_settings.py
@@ -10,7 +10,7 @@ from tether.settings import Settings
 def clean_env(monkeypatch):
     """Remove all TETHER_ env vars for clean tests."""
     for key in list(os.environ.keys()):
-        if key.startswith("TETHER_") or key == "ANTHROPIC_API_KEY":
+        if key.startswith("TETHER_") or key.startswith("DISCORD_") or key == "ANTHROPIC_API_KEY":
             monkeypatch.delenv(key, raising=False)
     return monkeypatch
 
@@ -170,7 +170,6 @@ class TestStringSettings:
         assert Settings.opencode_sidecar_cmd() == "my-opencode-sidecar --x"
         assert Settings.opencode_sidecar_startup_timeout_seconds() == 30
 
-
 class TestDataDir:
     """Test data directory setting."""
 
@@ -206,3 +205,11 @@ class TestDataDir:
 
         result = Settings.data_dir()
         assert result == str(tmp_path / "data" / "tether")
+
+
+class TestDiscordSettings:
+    """Test Discord-specific settings."""
+
+    def test_discord_auto_pair_user_ids(self, clean_env) -> None:
+        clean_env.setenv("DISCORD_AUTO_PAIR_USER_IDS", "123, nope, 456")
+        assert Settings.discord_auto_pair_user_ids() == {123, 456}

--- a/agent/tether/bridges/discord/bot.py
+++ b/agent/tether/bridges/discord/bot.py
@@ -1,3 +1,389 @@
-"""Compatibility shim: re-exports from agent_tether.discord.bot."""
-# ruff: noqa: F401
-from agent_tether.discord.bot import DiscordBridge, DiscordConfig
+"""Tether-local Discord bridge compatibility wrapper.
+
+Keep the upstream ``agent_tether`` bridge as the source of truth for Discord
+behavior, but override thread creation for text channels so new session threads
+are public and discoverable in the configured control channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import re
+import socket
+from typing import Any
+
+import structlog
+from agent_tether.discord.bot import DiscordBridge as UpstreamDiscordBridge
+from agent_tether.discord.bot import DiscordConfig as UpstreamDiscordConfig
+from agent_tether.discord.pairing_state import save as save_pairing_state
+
+logger = structlog.get_logger(__name__)
+
+_DISCORD_THREAD_NAME_LIMIT = 100
+_DISCORD_STARTER_TEXT_LIMIT = 2000
+_DISCORD_AUTO_ARCHIVE_MINUTES = 1440
+
+
+def _hostname_slug() -> str:
+    hostname = socket.gethostname().split(".", 1)[0].strip().lower()
+    slug = re.sub(r"[^a-z0-9-]+", "-", hostname).strip("-")
+    return slug or "tether"
+
+
+@dataclass
+class DiscordConfig:
+    """Tether-local Discord config compatibility shim."""
+
+    require_pairing: bool = False
+    allowed_user_ids: list[int] | None = None
+    auto_pair_user_ids: list[int] | None = None
+    pairing_code: str | None = None
+    guild_id: int = 0
+
+
+class DiscordBridge(UpstreamDiscordBridge):
+    """Compatibility wrapper for the upstream Discord bridge.
+
+    Upstream ``channel.create_thread(...)`` creates private threads when the
+    configured control channel is a regular Discord text channel. Those private
+    threads are effectively invisible in the machine channel, which makes the
+    Discord surface look empty. Tether needs visible public threads there.
+
+    For text channels, create a starter message and open the thread from that
+    message so Discord treats it as a public thread. For any other channel type,
+    fall back to upstream behavior unchanged.
+    """
+
+    def __init__(
+        self,
+        bot_token: str,
+        channel_id: int,
+        discord_config: DiscordConfig | UpstreamDiscordConfig | None = None,
+        **kwargs: Any,
+    ) -> None:
+        local_config = discord_config or DiscordConfig()
+        upstream_config = UpstreamDiscordConfig(
+            require_pairing=getattr(local_config, "require_pairing", False),
+            allowed_user_ids=getattr(local_config, "allowed_user_ids", None),
+            pairing_code=getattr(local_config, "pairing_code", None),
+        )
+        super().__init__(
+            bot_token=bot_token,
+            channel_id=channel_id,
+            discord_config=upstream_config,
+            **kwargs,
+        )
+        raw_auto_pair_ids = getattr(local_config, "auto_pair_user_ids", None) or []
+        auto_pair_user_ids: set[int] = set()
+        for user_id in raw_auto_pair_ids:
+            raw_user_id = str(user_id).strip()
+            if not raw_user_id:
+                continue
+            try:
+                auto_pair_user_ids.add(int(raw_user_id))
+            except ValueError:
+                continue
+        self._auto_pair_user_ids = auto_pair_user_ids
+        self._guild_id = int(getattr(local_config, "guild_id", 0) or 0)
+        self._control_channel_name = f"🤖-{_hostname_slug()}"
+        self._apply_auto_pair_users()
+
+    @staticmethod
+    def _parse_thread_id(raw_thread_id: object) -> int | None:
+        try:
+            thread_id = int(raw_thread_id or 0)
+        except (TypeError, ValueError):
+            return None
+        return thread_id or None
+
+    def _restore_thread_mappings_from_store(self) -> None:
+        try:
+            from tether.store import store
+        except Exception:
+            logger.exception("Failed to import store for Discord thread recovery")
+            return
+
+        for session in store.list_sessions():
+            if getattr(session, "platform", None) != "discord":
+                continue
+            thread_id = self._parse_thread_id(getattr(session, "platform_thread_id", None))
+            if thread_id is None:
+                continue
+            self._thread_ids.setdefault(session.id, thread_id)
+
+    def _hydrate_thread_binding(self, session_id: str) -> int | None:
+        thread_id = self._thread_ids.get(session_id)
+        if thread_id:
+            return thread_id
+
+        if self._get_session_info is not None:
+            try:
+                session_info = self._get_session_info(session_id)
+            except Exception:
+                logger.exception(
+                    "Failed to fetch session info for Discord thread recovery",
+                    session_id=session_id,
+                )
+            else:
+                if isinstance(session_info, dict):
+                    thread_id = self._parse_thread_id(
+                        session_info.get("platform_thread_id")
+                    )
+                    if thread_id is not None:
+                        self._thread_ids[session_id] = thread_id
+                        return thread_id
+
+        self._restore_thread_mappings_from_store()
+        return self._thread_ids.get(session_id)
+
+    async def on_output(
+        self, session_id: str, text: str, metadata: dict | None = None
+    ) -> None:
+        self._hydrate_thread_binding(session_id)
+        await super().on_output(session_id, text, metadata=metadata)
+
+    async def on_status_change(
+        self, session_id: str, status: str, metadata: dict | None = None
+    ) -> None:
+        self._hydrate_thread_binding(session_id)
+        await super().on_status_change(session_id, status, metadata=metadata)
+
+    async def on_approval_request(self, session_id: str, request) -> None:
+        self._hydrate_thread_binding(session_id)
+        await super().on_approval_request(session_id, request)
+
+    async def on_typing(self, session_id: str) -> None:
+        self._hydrate_thread_binding(session_id)
+        await super().on_typing(session_id)
+
+    async def send_auto_approve_batch(
+        self, session_id: str, items: list[tuple[str, str]]
+    ) -> None:
+        self._hydrate_thread_binding(session_id)
+        await super().send_auto_approve_batch(session_id, items)
+
+    async def start(self) -> None:
+        """Initialize and start Discord client."""
+        try:
+            import discord
+        except ImportError:
+            logger.error("discord.py not installed. Install with: pip install discord.py")
+            return
+
+        intents = discord.Intents.default()
+        intents.message_content = True
+        intents.reactions = True
+        if hasattr(intents, "guild_reactions"):
+            intents.guild_reactions = True
+        self._client = discord.Client(intents=intents)
+
+        @self._client.event
+        async def on_ready() -> None:
+            logger.info("Discord client ready", user=self._client.user)
+
+        @self._client.event
+        async def on_message(message: Any) -> None:
+            await self._handle_message(message)
+
+        asyncio.create_task(self._client.start(self._bot_token))
+
+        logger.info("Discord bridge initialized and starting", channel_id=self._channel_id)
+        if not self._channel_id and self._pairing_code:
+            logger.warning(
+                "Discord bridge not configured with a control channel. Run !setup <code> in the desired channel.",
+                code=self._pairing_code,
+            )
+        elif self._pairing_required and self._pairing_code:
+            logger.warning(
+                "Discord pairing enabled. DM the bot: !pair <code>",
+                code=self._pairing_code,
+            )
+
+    def _session_for_thread(self, thread_id: int) -> str | None:
+        session_id = super()._session_for_thread(thread_id)
+        if session_id:
+            return session_id
+        self._restore_thread_mappings_from_store()
+        return super()._session_for_thread(thread_id)
+
+    async def create_thread(self, session_id: str, session_name: str) -> dict:
+        if not self._client:
+            raise RuntimeError("Discord client not initialized")
+
+        channel = await self._ensure_control_channel()
+        if not channel:
+            raise RuntimeError(f"Discord channel {self._channel_id} not found")
+
+        if hasattr(channel, "send"):
+            return await self._create_public_thread_from_message(
+                session_id=session_id,
+                session_name=session_name,
+                channel=channel,
+            )
+
+        logger.info(
+            "Falling back to upstream Discord thread creation",
+            session_id=session_id,
+            channel_id=self._channel_id,
+        )
+        return await super().create_thread(session_id, session_name)
+
+    def _persist_control_channel(self) -> None:
+        self._ensure_pairing_state_loaded()
+        if self._pairing_state is None:
+            return
+        self._pairing_state.control_channel_id = int(self._channel_id)
+        self._pairing_state.paired_user_ids = set(self._paired_user_ids)
+        save_pairing_state(path=self._pairing_state_path, state=self._pairing_state)
+
+    def _apply_auto_pair_users(self) -> None:
+        if not self._auto_pair_user_ids:
+            return
+        self._ensure_pairing_state_loaded()
+        if self._pairing_state is None:
+            return
+        before = set(self._paired_user_ids)
+        self._paired_user_ids.update(self._auto_pair_user_ids)
+        if self._paired_user_ids == before:
+            return
+        self._pairing_state.paired_user_ids = set(self._paired_user_ids)
+        save_pairing_state(path=self._pairing_state_path, state=self._pairing_state)
+        logger.info(
+            "Auto-paired Discord users from configuration",
+            auto_pair_count=len(self._auto_pair_user_ids),
+        )
+
+    async def _resolve_bootstrap_guild(self) -> Any | None:
+        if not self._client:
+            return None
+
+        guilds = list(getattr(self._client, "guilds", []) or [])
+        if self._guild_id:
+            guild = self._client.get_guild(self._guild_id)
+            if guild is None:
+                logger.warning(
+                    "Configured Discord guild not found for control channel bootstrap",
+                    guild_id=self._guild_id,
+                    guild_count=len(guilds),
+                )
+            return guild
+
+        if len(guilds) == 1:
+            return guilds[0]
+
+        if len(guilds) > 1:
+            logger.warning(
+                "Discord control channel bootstrap needs DISCORD_GUILD_ID when the bot is in multiple guilds",
+                guild_count=len(guilds),
+            )
+            return None
+
+        logger.warning("Discord control channel bootstrap found no accessible guilds")
+        return None
+
+    async def _ensure_control_channel(self) -> Any | None:
+        if not self._client:
+            return None
+
+        if self._channel_id:
+            channel = self._client.get_channel(self._channel_id)
+            if channel is not None:
+                return channel
+            fetch_channel = getattr(self._client, "fetch_channel", None)
+            if fetch_channel is not None:
+                try:
+                    channel = await fetch_channel(self._channel_id)
+                except Exception:
+                    logger.warning(
+                        "Configured Discord control channel is not accessible; retrying bootstrap",
+                        channel_id=self._channel_id,
+                    )
+                else:
+                    return channel
+
+        guild = await self._resolve_bootstrap_guild()
+        if guild is None:
+            return None
+
+        for channel in getattr(guild, "text_channels", []) or []:
+            if getattr(channel, "name", None) != self._control_channel_name:
+                continue
+            self._channel_id = int(channel.id)
+            self._persist_control_channel()
+            logger.info(
+                "Using existing Discord control channel",
+                guild_id=getattr(guild, "id", 0),
+                channel_id=self._channel_id,
+                channel_name=self._control_channel_name,
+            )
+            return channel
+
+        topic = (
+            f"Tether control channel for {socket.gethostname().split('.', 1)[0]}. "
+            "Session threads are created from here automatically."
+        )
+        channel = await guild.create_text_channel(
+            name=self._control_channel_name,
+            topic=topic[:1024],
+        )
+        self._channel_id = int(channel.id)
+        self._persist_control_channel()
+        logger.info(
+            "Created Discord control channel",
+            guild_id=getattr(guild, "id", 0),
+            channel_id=self._channel_id,
+            channel_name=self._control_channel_name,
+        )
+        return channel
+
+    async def _create_public_thread_from_message(
+        self,
+        *,
+        session_id: str,
+        session_name: str,
+        channel: Any,
+    ) -> dict:
+        try:
+            self._reserve_thread_name(session_id, session_name)
+
+            starter_text = (
+                f"🧵 Tether session: **{session_name[:80]}**\n"
+                "This starter message keeps the thread visible in this machine channel."
+            )
+            starter_message = await channel.send(
+                starter_text[:_DISCORD_STARTER_TEXT_LIMIT]
+            )
+            thread = await starter_message.create_thread(
+                name=session_name[:_DISCORD_THREAD_NAME_LIMIT],
+                auto_archive_duration=_DISCORD_AUTO_ARCHIVE_MINUTES,
+            )
+
+            thread_id = thread.id
+            self._thread_ids[session_id] = thread_id
+            try:
+                await thread.send(
+                    "Tether session thread.\n"
+                    "Send a message here to provide input. Use `!stop` to interrupt, `!usage` for token usage."
+                )
+            except Exception:
+                pass
+
+            logger.info(
+                "Created visible Discord thread",
+                session_id=session_id,
+                thread_id=thread_id,
+                name=session_name,
+                channel_id=self._channel_id,
+            )
+            return {
+                "thread_id": str(thread_id),
+                "platform": "discord",
+            }
+        except Exception as exc:
+            logger.exception(
+                "Failed to create visible Discord thread", session_id=session_id
+            )
+            if self._thread_names.get(session_id) == session_name:
+                self._release_thread_name(session_id)
+            raise RuntimeError(f"Failed to create Discord thread: {exc}") from exc

--- a/agent/tether/main.py
+++ b/agent/tether/main.py
@@ -141,8 +141,7 @@ async def _init_bridges() -> None:
     discord_channel = settings.discord_channel_id()
     if discord_token:
         try:
-            from agent_tether import DiscordBridge
-            from agent_tether.discord.bot import DiscordConfig
+            from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
 
             bridge = DiscordBridge(
                 bot_token=discord_token,
@@ -150,7 +149,9 @@ async def _init_bridges() -> None:
                 discord_config=DiscordConfig(
                     require_pairing=settings.discord_require_pairing(),
                     allowed_user_ids=settings.discord_allowed_user_ids(),
+                    auto_pair_user_ids=settings.discord_auto_pair_user_ids(),
                     pairing_code=settings.discord_pairing_code(),
+                    guild_id=settings.discord_guild_id(),
                 ),
                 config=config,
                 callbacks=callbacks,
@@ -162,11 +163,19 @@ async def _init_bridges() -> None:
             bridge.restore_thread_mappings(sessions)
             bridge_manager.register_bridge("discord", bridge)
             if not discord_channel:
-                pairing_code = settings.discord_pairing_code() or bridge._pairing_code
-                logger.info(
-                    "Discord bridge started. Run !setup in your Discord channel to configure it.",
-                    code=pairing_code,
-                )
+                guild_id = settings.discord_guild_id()
+                if guild_id:
+                    logger.info(
+                        "Discord bridge started. The control channel will be auto-created or reused after the bot connects.",
+                        guild_id=guild_id,
+                        channel_name=bridge._control_channel_name,
+                    )
+                else:
+                    pairing_code = settings.discord_pairing_code() or bridge._pairing_code
+                    logger.info(
+                        "Discord bridge started. Run !setup in your Discord channel to configure it.",
+                        code=pairing_code,
+                    )
             else:
                 logger.info("Discord bridge registered and started")
         except Exception:

--- a/agent/tether/settings.py
+++ b/agent/tether/settings.py
@@ -40,6 +40,23 @@ def _get_int(name: str, default: int = 0) -> int:
         return default
 
 
+def _get_int_set(name: str) -> set[int]:
+    """Parse a comma-separated list of integer IDs."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return set()
+    out: set[int] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.add(int(part))
+        except ValueError:
+            continue
+    return out
+
+
 class Settings:
     """Centralized settings for the Tether agent.
 
@@ -389,6 +406,20 @@ class Settings:
             return 0
 
     @staticmethod
+    def discord_guild_id() -> int:
+        """Discord guild ID used for automatic control-channel bootstrap.
+
+        Env: DISCORD_GUILD_ID
+        """
+        value = os.environ.get("DISCORD_GUILD_ID", "").strip()
+        if not value:
+            return 0
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+
+    @staticmethod
     def discord_require_pairing() -> bool:
         """Require Discord users to pair before using the bot.
 
@@ -416,19 +447,15 @@ class Settings:
 
         Env: DISCORD_ALLOWED_USER_IDS (e.g. "123,456")
         """
-        raw = os.environ.get("DISCORD_ALLOWED_USER_IDS", "").strip()
-        if not raw:
-            return set()
-        out: set[int] = set()
-        for part in raw.split(","):
-            part = part.strip()
-            if not part:
-                continue
-            try:
-                out.add(int(part))
-            except ValueError:
-                continue
-        return out
+        return _get_int_set("DISCORD_ALLOWED_USER_IDS")
+
+    @staticmethod
+    def discord_auto_pair_user_ids() -> set[int]:
+        """Comma-separated Discord user IDs to pre-authorize as paired.
+
+        Env: DISCORD_AUTO_PAIR_USER_IDS (e.g. "123,456")
+        """
+        return _get_int_set("DISCORD_AUTO_PAIR_USER_IDS")
 
 
 # Singleton instance for convenient imports

--- a/docs/BRIDGES.md
+++ b/docs/BRIDGES.md
@@ -70,6 +70,7 @@ Routes store events to bridge methods:
 - Auto-approve sends `✅ **Tool** — auto-approved (reason)` notification
 - Optional pairing/allowlist: when enabled, only authorized Discord user IDs can run commands or send input
 - Optional no-ID setup: if `DISCORD_CHANNEL_ID` is unset, run `!setup <code>` in the desired channel to configure it
+- Optional guild bootstrap: if `DISCORD_GUILD_ID` is set and `DISCORD_CHANNEL_ID` is unset, Tether will create or reuse a host-named control channel such as `🤖-kali14`
 
 ## Auto-Approve System
 
@@ -90,9 +91,11 @@ Stored in base class as in-memory dicts:
 | `SLACK_CHANNEL_ID` | Slack channel ID |
 | `DISCORD_BOT_TOKEN` | Discord bot token |
 | `DISCORD_CHANNEL_ID` | Discord channel ID (int) |
+| `DISCORD_GUILD_ID` | Discord guild/server ID used for automatic control-channel creation |
 | `DISCORD_REQUIRE_PAIRING` | Require pairing before using the Discord bot (0/1) |
 | `DISCORD_PAIRING_CODE` | Optional fixed pairing code (if unset and pairing is required, one is generated and logged) |
 | `DISCORD_ALLOWED_USER_IDS` | Comma-separated Discord user IDs that are always authorized |
+| `DISCORD_AUTO_PAIR_USER_IDS` | Comma-separated Discord user IDs to seed into the paired-user set at launch |
 
 Bridges auto-initialize in `main.py` lifespan if tokens are configured.
 


### PR DESCRIPTION
## Summary

- replace the Discord shim with a Tether-local wrapper that can auto-create or reuse a host-named control channel when `DISCORD_GUILD_ID` is set
- create visible public threads in Discord text channels by starting them from a starter message instead of creating invisible private threads
- support `DISCORD_AUTO_PAIR_USER_IDS` so trusted operators can skip manual pairing
- recover persisted Discord thread bindings after restart so outputs, status changes, approvals, and typing events keep routing to the existing thread

## Usage

```env
DISCORD_BOT_TOKEN=...
DISCORD_GUILD_ID=123456789012345678
DISCORD_AUTO_PAIR_USER_IDS=111111111111111111,222222222222222222
```

Start Tether normally. When the bot connects, it will create or reuse a control channel like `🤖-kali14`, create public session threads inside it, and keep previously bound Discord threads alive across restarts.

## Validation

- `uv run --extra dev python -m pytest tests/test_discord_bridge.py tests/test_settings.py -q`
