### PR TITLE
[codex] Add reaction-driven session shortcuts

### DIFF
--- a/agent/tests/test_discord_bridge.py
+++ b/agent/tests/test_discord_bridge.py
@@ -1,5 +1,6 @@
 """Tests for Discord bridge (Phase 5 PoC)."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -78,6 +79,52 @@ class TestDiscordBridgePoC:
         assert mock_thread.send.called
 
     @pytest.mark.anyio
+    async def test_on_output_restores_thread_id_from_persisted_session(
+        self, fresh_store: SessionStore
+    ) -> None:
+        """Persisted thread bindings should recover after bridge state drift."""
+        from tether.bridges.discord.bot import DiscordBridge
+
+        session = fresh_store.create_session("repo_test", "main")
+        session.platform = "discord"
+        session.platform_thread_id = "9876543210"
+        fresh_store.update_session(session)
+
+        mock_client = MagicMock()
+        mock_thread = AsyncMock()
+        mock_client.get_channel.return_value = mock_thread
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=1234567890,
+        )
+        bridge._client = mock_client
+
+        await bridge.on_output(session.id, "Recovered Discord output")
+
+        assert bridge._thread_ids[session.id] == 9876543210
+        assert mock_thread.send.called
+
+    def test_session_for_thread_restores_mapping_from_store(
+        self, fresh_store: SessionStore
+    ) -> None:
+        """Inbound thread replies should still resolve after restart."""
+        from tether.bridges.discord.bot import DiscordBridge
+
+        session = fresh_store.create_session("repo_test", "main")
+        session.platform = "discord"
+        session.platform_thread_id = "9876543210"
+        fresh_store.update_session(session)
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=1234567890,
+        )
+
+        assert bridge._session_for_thread(9876543210) == session.id
+        assert bridge._thread_ids[session.id] == 9876543210
+
+    @pytest.mark.anyio
     async def test_create_thread_creates_discord_thread(
         self, fresh_store: SessionStore
     ) -> None:
@@ -89,9 +136,11 @@ class TestDiscordBridgePoC:
         # Mock Discord client
         mock_client = MagicMock()
         mock_channel = AsyncMock()
+        mock_starter_message = AsyncMock()
         mock_thread = MagicMock()
         mock_thread.id = 9876543210
-        mock_channel.create_thread.return_value = mock_thread
+        mock_starter_message.create_thread.return_value = mock_thread
+        mock_channel.send.return_value = mock_starter_message
         mock_client.get_channel.return_value = mock_channel
 
         bridge = DiscordBridge(
@@ -103,10 +152,156 @@ class TestDiscordBridgePoC:
         # Create thread
         result = await bridge.create_thread(session.id, "Test Session")
 
-        # Verify thread was created
-        assert mock_channel.create_thread.called
+        # Verify a visible thread was created from a starter message
+        assert mock_channel.send.called
+        assert mock_starter_message.create_thread.called
         assert result["thread_id"] == "9876543210"
         assert result["platform"] == "discord"
+
+    @pytest.mark.anyio
+    async def test_create_thread_fetches_preconfigured_channel_when_cache_empty(
+        self, fresh_store: SessionStore
+    ) -> None:
+        """Preconfigured control channels do not rely on Discord cache warmup."""
+        from tether.bridges.discord.bot import DiscordBridge
+
+        session = fresh_store.create_session("repo_test", "main")
+
+        mock_client = MagicMock()
+        fetched_channel = AsyncMock()
+        fetched_channel.id = 1234567890
+        mock_starter_message = AsyncMock()
+        mock_thread = MagicMock()
+        mock_thread.id = 222333444
+        mock_starter_message.create_thread.return_value = mock_thread
+        fetched_channel.send.return_value = mock_starter_message
+        mock_client.get_channel.return_value = None
+        mock_client.fetch_channel = AsyncMock(return_value=fetched_channel)
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=1234567890,
+        )
+        bridge._client = mock_client
+
+        result = await bridge.create_thread(session.id, "Fetched Channel Session")
+
+        mock_client.fetch_channel.assert_awaited_once_with(1234567890)
+        fetched_channel.send.assert_awaited_once()
+        mock_starter_message.create_thread.assert_awaited_once()
+        assert result["thread_id"] == "222333444"
+        assert result["platform"] == "discord"
+
+    @pytest.mark.anyio
+    async def test_auto_control_channel_reuses_existing_hostname_channel(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
+        from agent_tether.base import BridgeConfig
+
+        monkeypatch.setattr("tether.bridges.discord.bot.socket.gethostname", lambda: "box4080")
+
+        mock_client = MagicMock()
+        existing_channel = MagicMock()
+        existing_channel.id = 555
+        existing_channel.name = "🤖-box4080"
+        mock_guild = MagicMock()
+        mock_guild.id = 123456
+        mock_guild.text_channels = [existing_channel]
+        mock_client.get_guild.return_value = mock_guild
+        mock_client.guilds = [mock_guild]
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=0,
+            discord_config=DiscordConfig(guild_id=123456),
+            config=BridgeConfig(data_dir=str(tmp_path)),
+        )
+        bridge._client = mock_client
+
+        channel = await bridge._ensure_control_channel()
+
+        assert channel is existing_channel
+        assert bridge._channel_id == 555
+        assert not mock_guild.create_text_channel.called
+
+    @pytest.mark.anyio
+    async def test_auto_control_channel_creates_missing_hostname_channel(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
+        from agent_tether.base import BridgeConfig
+
+        monkeypatch.setattr("tether.bridges.discord.bot.socket.gethostname", lambda: "kali14")
+
+        mock_client = MagicMock()
+        created_channel = MagicMock()
+        created_channel.id = 777
+        created_channel.name = "🤖-kali14"
+        mock_guild = MagicMock()
+        mock_guild.id = 654321
+        mock_guild.text_channels = []
+        mock_guild.create_text_channel = AsyncMock(return_value=created_channel)
+        mock_client.get_guild.return_value = mock_guild
+        mock_client.guilds = [mock_guild]
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=0,
+            discord_config=DiscordConfig(guild_id=654321),
+            config=BridgeConfig(data_dir=str(tmp_path)),
+        )
+        bridge._client = mock_client
+
+        channel = await bridge._ensure_control_channel()
+
+        assert channel is created_channel
+        assert bridge._channel_id == 777
+        mock_guild.create_text_channel.assert_awaited_once()
+        assert mock_guild.create_text_channel.await_args.kwargs["name"] == "🤖-kali14"
+
+    @pytest.mark.anyio
+    async def test_create_thread_bootstraps_control_channel_when_unset(
+        self, fresh_store: SessionStore, monkeypatch, tmp_path
+    ) -> None:
+        from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
+        from agent_tether.base import BridgeConfig
+
+        monkeypatch.setattr("tether.bridges.discord.bot.socket.gethostname", lambda: "thinkpad1")
+
+        session = fresh_store.create_session("repo_test", "main")
+
+        control_channel = AsyncMock()
+        control_channel.id = 1001
+        control_channel.name = "🤖-thinkpad1"
+        starter_message = AsyncMock()
+        thread = MagicMock()
+        thread.id = 2002
+        starter_message.create_thread.return_value = thread
+        control_channel.send.return_value = starter_message
+
+        mock_guild = MagicMock()
+        mock_guild.id = 8080
+        mock_guild.text_channels = [control_channel]
+
+        mock_client = MagicMock()
+        mock_client.get_guild.return_value = mock_guild
+        mock_client.guilds = [mock_guild]
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=0,
+            discord_config=DiscordConfig(guild_id=8080),
+            config=BridgeConfig(data_dir=str(tmp_path)),
+        )
+        bridge._client = mock_client
+
+        result = await bridge.create_thread(session.id, "Test Session")
+
+        assert bridge._channel_id == 1001
+        control_channel.send.assert_awaited_once()
+        starter_message.create_thread.assert_awaited_once()
+        assert result["thread_id"] == "2002"
 
     @pytest.mark.anyio
     async def test_thread_names_are_unique_like_telegram(
@@ -118,9 +313,11 @@ class TestDiscordBridgePoC:
         # Mock Discord client
         mock_client = MagicMock()
         mock_channel = AsyncMock()
+        mock_starter_message = AsyncMock()
         mock_thread = MagicMock()
         mock_thread.id = 111
-        mock_channel.create_thread.return_value = mock_thread
+        mock_starter_message.create_thread.return_value = mock_thread
+        mock_channel.send.return_value = mock_starter_message
         mock_client.get_channel.return_value = mock_channel
 
         bridge = DiscordBridge(
@@ -130,18 +327,52 @@ class TestDiscordBridgePoC:
         )
         bridge._client = mock_client
 
-        name1 = bridge._make_external_thread_name(directory="/repo", session_id="sess_1")
+        name1 = bridge._make_external_thread_name(
+            directory="/repo", session_id="sess_1"
+        )
         await bridge.create_thread("sess_1", name1)
 
         mock_thread_2 = MagicMock()
         mock_thread_2.id = 222
-        mock_channel.create_thread.return_value = mock_thread_2
+        mock_starter_message_2 = AsyncMock()
+        mock_starter_message_2.create_thread.return_value = mock_thread_2
+        mock_channel.send.return_value = mock_starter_message_2
 
-        name2 = bridge._make_external_thread_name(directory="/repo", session_id="sess_2")
+        name2 = bridge._make_external_thread_name(
+            directory="/repo", session_id="sess_2"
+        )
         await bridge.create_thread("sess_2", name2)
 
         assert name1 == "Repo"
         assert name2 == "Repo 2"
+
+    @pytest.mark.anyio
+    async def test_create_thread_falls_back_for_non_text_channels(
+        self, fresh_store: SessionStore
+    ) -> None:
+        """Non-text Discord channels still use the upstream thread creation path."""
+        from tether.bridges.discord.bot import DiscordBridge
+
+        session = fresh_store.create_session("repo_test", "main")
+
+        mock_client = MagicMock()
+        mock_channel = object()
+        mock_client.get_channel.return_value = mock_channel
+
+        bridge = DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=1234567890,
+        )
+        bridge._client = mock_client
+
+        with patch(
+            "agent_tether.discord.bot.DiscordBridge.create_thread",
+            new=AsyncMock(return_value={"thread_id": "321", "platform": "discord"}),
+        ) as create_thread:
+            result = await bridge.create_thread(session.id, "Fallback Session")
+
+        assert create_thread.await_count == 1
+        assert result["thread_id"] == "321"
 
     @pytest.mark.anyio
     async def test_on_status_change_sends_to_discord(
@@ -461,6 +692,40 @@ class TestDiscordBridgePoC:
         callbacks.list_sessions.assert_called_once()
 
     @pytest.mark.anyio
+    async def test_auto_pair_user_ids_authorize_commands(
+        self, tmp_path
+    ) -> None:
+        from agent_tether.base import BridgeConfig
+        from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
+
+        callbacks = _mock_callbacks()
+        bridge = DiscordBridge(
+            bot_token="x",
+            channel_id=1234567890,
+            discord_config=DiscordConfig(
+                require_pairing=True,
+                auto_pair_user_ids=[222],
+            ),
+            callbacks=callbacks,
+            config=BridgeConfig(data_dir=str(tmp_path)),
+        )
+
+        mock_channel = AsyncMock()
+        mock_channel.id = 1234567890
+        mock_message = MagicMock()
+        mock_message.channel = mock_channel
+        mock_message.guild = MagicMock()
+        mock_message.author.id = 222
+        mock_message.author.name = "testuser"
+
+        await bridge._dispatch_command(mock_message, "!status")
+
+        assert 222 in bridge._paired_user_ids
+        callbacks.list_sessions.assert_called_once()
+        pairing_payload = json.loads((tmp_path / "discord_pairing.json").read_text("utf-8"))
+        assert pairing_payload["paired_user_ids"] == [222]
+
+    @pytest.mark.anyio
     async def test_setup_command_sets_control_channel_and_pairs_user(
         self, fresh_store: SessionStore, monkeypatch
     ) -> None:
@@ -518,9 +783,10 @@ class TestDiscordBridgePoC:
         # Stop typing indicator
         await bridge.on_typing_stopped(session.id)
         assert session.id not in bridge._typing_tasks
-        
+
         # Give the task a moment to cancel
         import asyncio
+
         await asyncio.sleep(0.01)
         assert typing_task.cancelled() or typing_task.done()
 

--- a/agent/tests/test_reaction_shortcut_parser_contract.py
+++ b/agent/tests/test_reaction_shortcut_parser_contract.py
@@ -1,0 +1,98 @@
+"""Contract tests for the planned checkmark-reaction shortcut."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent_tether.base import BridgeCallbacks
+from tether.bridges.reaction_shortcuts import (
+    parse_reaction_shortcut_message,
+    reaction_matches,
+)
+
+
+def _mock_callbacks(**overrides) -> BridgeCallbacks:
+    defaults = dict(
+        create_session=AsyncMock(return_value={}),
+        send_input=AsyncMock(),
+        stop_session=AsyncMock(),
+        respond_to_permission=AsyncMock(return_value=True),
+        list_sessions=AsyncMock(return_value=[]),
+        get_usage=AsyncMock(return_value={}),
+        check_directory=AsyncMock(side_effect=lambda path: {"exists": True, "path": path}),
+        list_external_sessions=AsyncMock(return_value=[]),
+        get_external_history=AsyncMock(return_value=None),
+        attach_external=AsyncMock(return_value={}),
+    )
+    defaults.update(overrides)
+    return BridgeCallbacks(**defaults)
+
+
+def _make_bridge(platform: str, **kwargs):
+    if platform == "slack":
+        from tether.bridges.slack.bot import SlackBridge
+
+        return SlackBridge(
+            bot_token="xoxb-test-token",
+            channel_id="C01234567",
+            **kwargs,
+        )
+    if platform == "discord":
+        from tether.bridges.discord.bot import DiscordBridge
+
+        return DiscordBridge(
+            bot_token="discord_bot_token",
+            channel_id=1234567890,
+            **kwargs,
+        )
+    raise AssertionError(f"Unsupported platform: {platform}")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("platform", ["slack", "discord"])
+async def test_top_level_reaction_contract_requires_directory_for_agent_only_message(
+    platform: str,
+) -> None:
+    bridge = _make_bridge(platform, callbacks=_mock_callbacks())
+
+    with pytest.raises(ValueError, match=r"Usage: !new <agent> <directory>"):
+        await bridge._parse_new_args("codex", base_session_id=None)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("platform", ["slack", "discord"])
+async def test_thread_seeded_reaction_contract_reuses_base_directory_for_agent_only_message(
+    platform: str,
+) -> None:
+    bridge = _make_bridge(
+        platform,
+        callbacks=_mock_callbacks(),
+        get_session_info=lambda _session_id: {
+            "directory": "/worktrees/demo",
+            "adapter": "claude_auto",
+        },
+    )
+
+    adapter, directory = await bridge._parse_new_args(
+        "codex",
+        base_session_id="sess_existing",
+    )
+
+    assert adapter == "codex_sdk_sidecar"
+    assert directory == "/worktrees/demo"
+
+
+def test_parse_reaction_shortcut_message_extracts_args_and_prompt() -> None:
+    shortcut = parse_reaction_shortcut_message(
+        "!new codex /worktrees/tether\nFix the failing Discord tests."
+    )
+
+    assert shortcut is not None
+    assert shortcut.args == "codex /worktrees/tether"
+    assert shortcut.prompt == "Fix the failing Discord tests."
+
+
+def test_reaction_matches_accepts_slack_and_discord_checkmark_forms() -> None:
+    assert reaction_matches("✅", "white_check_mark") is True
+    assert reaction_matches("white_check_mark", "✅") is True
+    assert reaction_matches("✅", "eyes") is False

--- a/agent/tests/test_reaction_shortcuts_planned.py
+++ b/agent/tests/test_reaction_shortcuts_planned.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent_tether.base import BridgeCallbacks
+
+
+def _mock_callbacks(**overrides) -> BridgeCallbacks:
+    defaults = dict(
+        create_session=AsyncMock(return_value={}),
+        send_input=AsyncMock(),
+        stop_session=AsyncMock(),
+        respond_to_permission=AsyncMock(return_value=True),
+        list_sessions=AsyncMock(return_value=[]),
+        get_usage=AsyncMock(return_value={}),
+        check_directory=AsyncMock(side_effect=lambda path: {"exists": True, "path": path}),
+        list_external_sessions=AsyncMock(return_value=[]),
+        get_external_history=AsyncMock(return_value=None),
+        attach_external=AsyncMock(return_value={}),
+    )
+    defaults.update(overrides)
+    return BridgeCallbacks(**defaults)
+
+
+@pytest.mark.anyio
+async def test_discord_checkmark_reaction_creates_and_starts_session_from_control_channel_message() -> None:
+    from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
+
+    callbacks = _mock_callbacks(
+        create_session=AsyncMock(
+            return_value={"id": "sess_discord", "platform_thread_id": "333"}
+        ),
+    )
+    bridge = DiscordBridge(
+        bot_token="discord_bot_token",
+        channel_id=1234567890,
+        discord_config=DiscordConfig(
+            reaction_new_session_enabled=True,
+            reaction_new_session_emoji="✅",
+        ),
+        callbacks=callbacks,
+    )
+
+    control_channel = AsyncMock()
+    control_channel.id = 1234567890
+    source_message = MagicMock()
+    source_message.content = "!new codex /repo\nFix the Discord reaction flow."
+    source_message.author.bot = False
+    control_channel.fetch_message = AsyncMock(return_value=source_message)
+
+    mock_client = MagicMock()
+    mock_client.user = MagicMock(id=9999)
+    mock_client.get_channel.return_value = control_channel
+    bridge._client = mock_client
+
+    payload = MagicMock()
+    payload.channel_id = 1234567890
+    payload.message_id = 4444
+    payload.user_id = 1111
+    payload.emoji = MagicMock()
+    payload.emoji.name = "✅"
+
+    await bridge._handle_raw_reaction_add(payload)
+
+    create_kwargs = callbacks.create_session.await_args.kwargs
+    assert create_kwargs["directory"] == "/repo"
+    assert create_kwargs["platform"] == "discord"
+    assert create_kwargs["adapter"] == "codex_sdk_sidecar"
+    assert callbacks.send_input.await_args.args == (
+        "sess_discord",
+        "Fix the Discord reaction flow.",
+    )
+    control_channel.send.assert_awaited()
+    assert "<#333>" in control_channel.send.await_args.args[0]
+
+
+@pytest.mark.anyio
+async def test_discord_checkmark_reaction_ignores_threads_unauthorized_users_and_duplicate_events(
+    tmp_path,
+) -> None:
+    from agent_tether.base import BridgeConfig
+    from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
+
+    callbacks = _mock_callbacks(
+        create_session=AsyncMock(
+            return_value={"id": "sess_discord", "platform_thread_id": "333"}
+        ),
+    )
+    bridge = DiscordBridge(
+        bot_token="discord_bot_token",
+        channel_id=1234567890,
+        discord_config=DiscordConfig(
+            require_pairing=True,
+            pairing_code="12345678",
+            reaction_new_session_enabled=True,
+        ),
+        callbacks=callbacks,
+        config=BridgeConfig(data_dir=str(tmp_path)),
+    )
+
+    thread_channel = AsyncMock()
+    thread_channel.id = 999999999
+    thread_message = MagicMock()
+    thread_message.content = "!new codex /repo\nIgnore thread reactions."
+    thread_message.author.bot = False
+    thread_channel.fetch_message = AsyncMock(return_value=thread_message)
+
+    control_channel = AsyncMock()
+    control_channel.id = 1234567890
+    control_message = MagicMock()
+    control_message.content = "!new codex /repo\nBuild one session only."
+    control_message.author.bot = False
+    control_channel.fetch_message = AsyncMock(return_value=control_message)
+
+    mock_client = MagicMock()
+    mock_client.user = MagicMock(id=9999)
+    mock_client.get_channel.side_effect = lambda channel_id: {
+        1234567890: control_channel,
+        999999999: thread_channel,
+    }.get(channel_id)
+    bridge._client = mock_client
+
+    unauthorized_payload = MagicMock()
+    unauthorized_payload.channel_id = 1234567890
+    unauthorized_payload.message_id = 1001
+    unauthorized_payload.user_id = 2002
+    unauthorized_payload.emoji = MagicMock()
+    unauthorized_payload.emoji.name = "✅"
+
+    await bridge._handle_raw_reaction_add(unauthorized_payload)
+
+    thread_payload = MagicMock()
+    thread_payload.channel_id = 999999999
+    thread_payload.message_id = 1002
+    thread_payload.user_id = 2002
+    thread_payload.emoji = MagicMock()
+    thread_payload.emoji.name = "✅"
+
+    await bridge._handle_raw_reaction_add(thread_payload)
+
+    bridge._allowed_user_ids = [2002]
+    valid_payload = MagicMock()
+    valid_payload.channel_id = 1234567890
+    valid_payload.message_id = 1003
+    valid_payload.user_id = 2002
+    valid_payload.emoji = MagicMock()
+    valid_payload.emoji.name = "✅"
+
+    await bridge._handle_raw_reaction_add(valid_payload)
+    await bridge._handle_raw_reaction_add(valid_payload)
+
+    assert callbacks.create_session.await_count == 1
+    assert callbacks.send_input.await_count == 1
+    assert thread_channel.fetch_message.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_slack_checkmark_reaction_creates_and_starts_session_from_control_channel_message() -> None:
+    from tether.bridges.slack.bot import SlackBridge
+
+    callbacks = _mock_callbacks(
+        create_session=AsyncMock(
+            return_value={"id": "sess_slack", "platform_thread_id": "555.666"}
+        ),
+    )
+    bridge = SlackBridge(
+        bot_token="xoxb-test-token",
+        channel_id="C01234567",
+        callbacks=callbacks,
+        reaction_new_session_enabled=True,
+        reaction_new_session_emoji="✅",
+    )
+
+    mock_client = AsyncMock()
+    mock_client.conversations_history.return_value = {
+        "ok": True,
+        "messages": [
+            {
+                "text": "!new codex /repo\nFix the Slack reaction flow.",
+                "ts": "111.222",
+            }
+        ],
+    }
+    bridge._client = mock_client
+
+    await bridge._handle_reaction_added(
+        {
+            "reaction": "white_check_mark",
+            "item": {"channel": "C01234567", "ts": "111.222"},
+            "user": "U123",
+        }
+    )
+
+    create_kwargs = callbacks.create_session.await_args.kwargs
+    assert create_kwargs["directory"] == "/repo"
+    assert create_kwargs["platform"] == "slack"
+    assert create_kwargs["adapter"] == "codex_sdk_sidecar"
+    assert callbacks.send_input.await_args.args == (
+        "sess_slack",
+        "Fix the Slack reaction flow.",
+    )
+    assert mock_client.chat_postMessage.await_count == 1
+    assert "New Codex session created in repo" in mock_client.chat_postMessage.await_args.kwargs["text"]
+
+
+@pytest.mark.anyio
+async def test_slack_checkmark_reaction_ignores_non_checkmark_reactions_and_thread_messages() -> None:
+    from tether.bridges.slack.bot import SlackBridge
+
+    callbacks = _mock_callbacks(
+        create_session=AsyncMock(
+            return_value={"id": "sess_slack", "platform_thread_id": "555.666"}
+        ),
+    )
+    bridge = SlackBridge(
+        bot_token="xoxb-test-token",
+        channel_id="C01234567",
+        callbacks=callbacks,
+        reaction_new_session_enabled=True,
+    )
+
+    mock_client = AsyncMock()
+    mock_client.conversations_history.return_value = {
+        "ok": True,
+        "messages": [
+            {
+                "text": "!new codex /repo\nIgnore thread reactions.",
+                "ts": "111.222",
+                "thread_ts": "999.000",
+            }
+        ],
+    }
+    bridge._client = mock_client
+
+    await bridge._handle_reaction_added(
+        {
+            "reaction": "eyes",
+            "item": {"channel": "C01234567", "ts": "111.222"},
+        }
+    )
+    await bridge._handle_reaction_added(
+        {
+            "reaction": "white_check_mark",
+            "item": {"channel": "C01234567", "ts": "111.222"},
+        }
+    )
+    await bridge._handle_reaction_added(
+        {
+            "reaction": "white_check_mark",
+            "item": {"channel": "C01234567", "ts": "111.222"},
+        }
+    )
+
+    assert callbacks.create_session.await_count == 0
+    assert callbacks.send_input.await_count == 0

--- a/agent/tests/test_settings.py
+++ b/agent/tests/test_settings.py
@@ -170,6 +170,18 @@ class TestStringSettings:
         assert Settings.opencode_sidecar_cmd() == "my-opencode-sidecar --x"
         assert Settings.opencode_sidecar_startup_timeout_seconds() == 30
 
+    def test_bridge_reaction_shortcut_settings(self, clean_env) -> None:
+        """Reaction shortcut settings have safe defaults and overrides."""
+        assert Settings.bridge_reaction_new_session_enabled() is True
+        assert Settings.bridge_reaction_new_session_emoji() == "✅"
+
+        clean_env.setenv("TETHER_BRIDGE_REACTION_NEW_SESSION_ENABLED", "0")
+        clean_env.setenv("TETHER_BRIDGE_REACTION_NEW_SESSION_EMOJI", "white_check_mark")
+
+        assert Settings.bridge_reaction_new_session_enabled() is False
+        assert Settings.bridge_reaction_new_session_emoji() == "white_check_mark"
+
+
 class TestDataDir:
     """Test data directory setting."""
 

--- a/agent/tests/test_settings.py
+++ b/agent/tests/test_settings.py
@@ -10,7 +10,7 @@ from tether.settings import Settings
 def clean_env(monkeypatch):
     """Remove all TETHER_ env vars for clean tests."""
     for key in list(os.environ.keys()):
-        if key.startswith("TETHER_") or key == "ANTHROPIC_API_KEY":
+        if key.startswith("TETHER_") or key.startswith("DISCORD_") or key == "ANTHROPIC_API_KEY":
             monkeypatch.delenv(key, raising=False)
     return monkeypatch
 
@@ -170,7 +170,6 @@ class TestStringSettings:
         assert Settings.opencode_sidecar_cmd() == "my-opencode-sidecar --x"
         assert Settings.opencode_sidecar_startup_timeout_seconds() == 30
 
-
 class TestDataDir:
     """Test data directory setting."""
 
@@ -206,3 +205,11 @@ class TestDataDir:
 
         result = Settings.data_dir()
         assert result == str(tmp_path / "data" / "tether")
+
+
+class TestDiscordSettings:
+    """Test Discord-specific settings."""
+
+    def test_discord_auto_pair_user_ids(self, clean_env) -> None:
+        clean_env.setenv("DISCORD_AUTO_PAIR_USER_IDS", "123, nope, 456")
+        assert Settings.discord_auto_pair_user_ids() == {123, 456}

--- a/agent/tests/test_slack_bridge.py
+++ b/agent/tests/test_slack_bridge.py
@@ -48,9 +48,10 @@ class TestSlackBridgePoC:
 
     @pytest.mark.anyio
     async def test_thread_names_are_unique_like_telegram(
-        self, fresh_store: SessionStore
+        self, fresh_store: SessionStore, tmp_path
     ) -> None:
         """Second thread with same directory gets 'Name 2'."""
+        from agent_tether.base import BridgeConfig
         from tether.bridges.slack.bot import SlackBridge
 
         mock_client = AsyncMock()
@@ -59,7 +60,11 @@ class TestSlackBridgePoC:
             {"ok": True, "ts": "2"},
         ]
 
-        bridge = SlackBridge(bot_token="xoxb-test-token", channel_id="C01234567")
+        bridge = SlackBridge(
+            bot_token="xoxb-test-token",
+            channel_id="C01234567",
+            config=BridgeConfig(data_dir=str(tmp_path)),
+        )
         bridge._client = mock_client
 
         name1 = bridge._make_external_thread_name(directory="/repo", session_id="sess_1")

--- a/agent/tether/bridges/discord/bot.py
+++ b/agent/tether/bridges/discord/bot.py
@@ -17,6 +17,13 @@ import structlog
 from agent_tether.discord.bot import DiscordBridge as UpstreamDiscordBridge
 from agent_tether.discord.bot import DiscordConfig as UpstreamDiscordConfig
 from agent_tether.discord.pairing_state import save as save_pairing_state
+from agent_tether.thread_naming import adapter_to_runner
+
+from tether.bridges.reaction_shortcuts import (
+    ReactionShortcutError,
+    parse_reaction_shortcut_message,
+    reaction_matches,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -40,6 +47,8 @@ class DiscordConfig:
     auto_pair_user_ids: list[int] | None = None
     pairing_code: str | None = None
     guild_id: int = 0
+    reaction_new_session_enabled: bool = True
+    reaction_new_session_emoji: str = "✅"
 
 
 class DiscordBridge(UpstreamDiscordBridge):
@@ -87,6 +96,14 @@ class DiscordBridge(UpstreamDiscordBridge):
         self._auto_pair_user_ids = auto_pair_user_ids
         self._guild_id = int(getattr(local_config, "guild_id", 0) or 0)
         self._control_channel_name = f"🤖-{_hostname_slug()}"
+        self._reaction_new_session_enabled = bool(
+            getattr(local_config, "reaction_new_session_enabled", True)
+        )
+        self._reaction_new_session_emoji = (
+            getattr(local_config, "reaction_new_session_emoji", "✅") or "✅"
+        )
+        self._reaction_shortcuts_completed: set[int] = set()
+        self._reaction_shortcuts_in_progress: set[int] = set()
         self._apply_auto_pair_users()
 
     @staticmethod
@@ -180,11 +197,19 @@ class DiscordBridge(UpstreamDiscordBridge):
 
         @self._client.event
         async def on_ready() -> None:
-            logger.info("Discord client ready", user=self._client.user)
+            logger.info(
+                "Discord client ready",
+                user=self._client.user,
+                reaction_shortcuts=self._reaction_new_session_enabled,
+            )
 
         @self._client.event
         async def on_message(message: Any) -> None:
             await self._handle_message(message)
+
+        @self._client.event
+        async def on_raw_reaction_add(payload: Any) -> None:
+            await self._handle_raw_reaction_add(payload)
 
         asyncio.create_task(self._client.start(self._bot_token))
 
@@ -253,6 +278,21 @@ class DiscordBridge(UpstreamDiscordBridge):
             "Auto-paired Discord users from configuration",
             auto_pair_count=len(self._auto_pair_user_ids),
         )
+
+    def _begin_reaction_shortcut(self, source_message_id: int) -> bool:
+        if source_message_id in self._reaction_shortcuts_completed:
+            return False
+        if source_message_id in self._reaction_shortcuts_in_progress:
+            return False
+        self._reaction_shortcuts_in_progress.add(source_message_id)
+        return True
+
+    def _finish_reaction_shortcut(
+        self, source_message_id: int, *, persist: bool
+    ) -> None:
+        self._reaction_shortcuts_in_progress.discard(source_message_id)
+        if persist:
+            self._reaction_shortcuts_completed.add(source_message_id)
 
     async def _resolve_bootstrap_guild(self) -> Any | None:
         if not self._client:
@@ -336,6 +376,108 @@ class DiscordBridge(UpstreamDiscordBridge):
             channel_name=self._control_channel_name,
         )
         return channel
+
+    async def _handle_raw_reaction_add(self, payload: Any) -> None:
+        """Create and start a new session from a reacted control-channel message."""
+        if not self._reaction_new_session_enabled or not self._client:
+            return
+
+        channel_id = int(getattr(payload, "channel_id", 0) or 0)
+        if not self._channel_id or channel_id != int(self._channel_id):
+            return
+
+        source_message_id = int(getattr(payload, "message_id", 0) or 0)
+        if not source_message_id:
+            return
+
+        user_id = int(getattr(payload, "user_id", 0) or 0)
+        client_user_id = int(getattr(getattr(self._client, "user", None), "id", 0) or 0)
+        if client_user_id and user_id == client_user_id:
+            return
+        if not self._is_authorized_user_id(user_id):
+            return
+
+        emoji_name = getattr(getattr(payload, "emoji", None), "name", None) or str(
+            getattr(payload, "emoji", "") or ""
+        )
+        if not reaction_matches(self._reaction_new_session_emoji, emoji_name):
+            return
+        if not self._begin_reaction_shortcut(source_message_id):
+            return
+
+        persist = False
+        channel: Any | None = None
+        try:
+            channel = self._client.get_channel(channel_id)
+            if channel is None:
+                fetch_channel = getattr(self._client, "fetch_channel", None)
+                if fetch_channel is not None:
+                    channel = await fetch_channel(channel_id)
+            if channel is None or not hasattr(channel, "fetch_message"):
+                return
+
+            message = await channel.fetch_message(source_message_id)
+            if getattr(getattr(message, "author", None), "bot", False):
+                return
+
+            shortcut = parse_reaction_shortcut_message(getattr(message, "content", ""))
+            if shortcut is None:
+                return
+
+            adapter, directory = await self._parse_new_args(
+                shortcut.args,
+                base_session_id=None,
+            )
+            dir_short = directory.rstrip("/").rsplit("/", 1)[-1] or "Session"
+            agent_label = (
+                self._adapter_label(adapter)
+                or self._adapter_label(self._config.default_adapter)
+                or "Claude"
+            )
+            runner_type = adapter_to_runner(adapter or self._config.default_adapter)
+            session_name = self._make_external_thread_name(
+                directory=directory,
+                session_id="",
+                runner_type=runner_type,
+            )
+
+            session = await self._create_session_via_api(
+                directory=directory,
+                platform="discord",
+                adapter=adapter,
+                session_name=session_name,
+            )
+            session_id = str(session.get("id") or "").strip()
+            if not session_id:
+                raise RuntimeError("Tether did not return a session id")
+
+            persist = True
+            await self._send_input_or_start_via_api(
+                session_id=session_id,
+                text=shortcut.prompt,
+            )
+            reply = (
+                f"✅ New {agent_label} session created in {dir_short} from a checkmark reaction."
+            )
+            try:
+                thread_id = int(session.get("platform_thread_id") or 0)
+            except Exception:
+                thread_id = 0
+            if thread_id:
+                reply += f"\n🧵 Open thread: <#{thread_id}>"
+            await channel.send(reply[:_DISCORD_STARTER_TEXT_LIMIT])
+        except (ReactionShortcutError, ValueError) as exc:
+            if channel is not None:
+                await channel.send(str(exc))
+        except Exception as exc:
+            logger.exception(
+                "Failed to create Discord session from reaction",
+                source_message_id=source_message_id,
+            )
+            if channel is not None:
+                await channel.send(f"Failed to create session from reaction: {exc}")
+        finally:
+            self._finish_reaction_shortcut(source_message_id, persist=persist)
 
     async def _create_public_thread_from_message(
         self,

--- a/agent/tether/bridges/discord/bot.py
+++ b/agent/tether/bridges/discord/bot.py
@@ -1,3 +1,389 @@
-"""Compatibility shim: re-exports from agent_tether.discord.bot."""
-# ruff: noqa: F401
-from agent_tether.discord.bot import DiscordBridge, DiscordConfig
+"""Tether-local Discord bridge compatibility wrapper.
+
+Keep the upstream ``agent_tether`` bridge as the source of truth for Discord
+behavior, but override thread creation for text channels so new session threads
+are public and discoverable in the configured control channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import re
+import socket
+from typing import Any
+
+import structlog
+from agent_tether.discord.bot import DiscordBridge as UpstreamDiscordBridge
+from agent_tether.discord.bot import DiscordConfig as UpstreamDiscordConfig
+from agent_tether.discord.pairing_state import save as save_pairing_state
+
+logger = structlog.get_logger(__name__)
+
+_DISCORD_THREAD_NAME_LIMIT = 100
+_DISCORD_STARTER_TEXT_LIMIT = 2000
+_DISCORD_AUTO_ARCHIVE_MINUTES = 1440
+
+
+def _hostname_slug() -> str:
+    hostname = socket.gethostname().split(".", 1)[0].strip().lower()
+    slug = re.sub(r"[^a-z0-9-]+", "-", hostname).strip("-")
+    return slug or "tether"
+
+
+@dataclass
+class DiscordConfig:
+    """Tether-local Discord config compatibility shim."""
+
+    require_pairing: bool = False
+    allowed_user_ids: list[int] | None = None
+    auto_pair_user_ids: list[int] | None = None
+    pairing_code: str | None = None
+    guild_id: int = 0
+
+
+class DiscordBridge(UpstreamDiscordBridge):
+    """Compatibility wrapper for the upstream Discord bridge.
+
+    Upstream ``channel.create_thread(...)`` creates private threads when the
+    configured control channel is a regular Discord text channel. Those private
+    threads are effectively invisible in the machine channel, which makes the
+    Discord surface look empty. Tether needs visible public threads there.
+
+    For text channels, create a starter message and open the thread from that
+    message so Discord treats it as a public thread. For any other channel type,
+    fall back to upstream behavior unchanged.
+    """
+
+    def __init__(
+        self,
+        bot_token: str,
+        channel_id: int,
+        discord_config: DiscordConfig | UpstreamDiscordConfig | None = None,
+        **kwargs: Any,
+    ) -> None:
+        local_config = discord_config or DiscordConfig()
+        upstream_config = UpstreamDiscordConfig(
+            require_pairing=getattr(local_config, "require_pairing", False),
+            allowed_user_ids=getattr(local_config, "allowed_user_ids", None),
+            pairing_code=getattr(local_config, "pairing_code", None),
+        )
+        super().__init__(
+            bot_token=bot_token,
+            channel_id=channel_id,
+            discord_config=upstream_config,
+            **kwargs,
+        )
+        raw_auto_pair_ids = getattr(local_config, "auto_pair_user_ids", None) or []
+        auto_pair_user_ids: set[int] = set()
+        for user_id in raw_auto_pair_ids:
+            raw_user_id = str(user_id).strip()
+            if not raw_user_id:
+                continue
+            try:
+                auto_pair_user_ids.add(int(raw_user_id))
+            except ValueError:
+                continue
+        self._auto_pair_user_ids = auto_pair_user_ids
+        self._guild_id = int(getattr(local_config, "guild_id", 0) or 0)
+        self._control_channel_name = f"🤖-{_hostname_slug()}"
+        self._apply_auto_pair_users()
+
+    @staticmethod
+    def _parse_thread_id(raw_thread_id: object) -> int | None:
+        try:
+            thread_id = int(raw_thread_id or 0)
+        except (TypeError, ValueError):
+            return None
+        return thread_id or None
+
+    def _restore_thread_mappings_from_store(self) -> None:
+        try:
+            from tether.store import store
+        except Exception:
+            logger.exception("Failed to import store for Discord thread recovery")
+            return
+
+        for session in store.list_sessions():
+            if getattr(session, "platform", None) != "discord":
+                continue
+            thread_id = self._parse_thread_id(getattr(session, "platform_thread_id", None))
+            if thread_id is None:
+                continue
+            self._thread_ids.setdefault(session.id, thread_id)
+
+    def _hydrate_thread_binding(self, session_id: str) -> int | None:
+        thread_id = self._thread_ids.get(session_id)
+        if thread_id:
+            return thread_id
+
+        if self._get_session_info is not None:
+            try:
+                session_info = self._get_session_info(session_id)
+            except Exception:
+                logger.exception(
+                    "Failed to fetch session info for Discord thread recovery",
+                    session_id=session_id,
+                )
+            else:
+                if isinstance(session_info, dict):
+                    thread_id = self._parse_thread_id(
+                        session_info.get("platform_thread_id")
+                    )
+                    if thread_id is not None:
+                        self._thread_ids[session_id] = thread_id
+                        return thread_id
+
+        self._restore_thread_mappings_from_store()
+        return self._thread_ids.get(session_id)
+
+    async def on_output(
+        self, session_id: str, text: str, metadata: dict | None = None
+    ) -> None:
+        self._hydrate_thread_binding(session_id)
+        await super().on_output(session_id, text, metadata=metadata)
+
+    async def on_status_change(
+        self, session_id: str, status: str, metadata: dict | None = None
+    ) -> None:
+        self._hydrate_thread_binding(session_id)
+        await super().on_status_change(session_id, status, metadata=metadata)
+
+    async def on_approval_request(self, session_id: str, request) -> None:
+        self._hydrate_thread_binding(session_id)
+        await super().on_approval_request(session_id, request)
+
+    async def on_typing(self, session_id: str) -> None:
+        self._hydrate_thread_binding(session_id)
+        await super().on_typing(session_id)
+
+    async def send_auto_approve_batch(
+        self, session_id: str, items: list[tuple[str, str]]
+    ) -> None:
+        self._hydrate_thread_binding(session_id)
+        await super().send_auto_approve_batch(session_id, items)
+
+    async def start(self) -> None:
+        """Initialize and start Discord client."""
+        try:
+            import discord
+        except ImportError:
+            logger.error("discord.py not installed. Install with: pip install discord.py")
+            return
+
+        intents = discord.Intents.default()
+        intents.message_content = True
+        intents.reactions = True
+        if hasattr(intents, "guild_reactions"):
+            intents.guild_reactions = True
+        self._client = discord.Client(intents=intents)
+
+        @self._client.event
+        async def on_ready() -> None:
+            logger.info("Discord client ready", user=self._client.user)
+
+        @self._client.event
+        async def on_message(message: Any) -> None:
+            await self._handle_message(message)
+
+        asyncio.create_task(self._client.start(self._bot_token))
+
+        logger.info("Discord bridge initialized and starting", channel_id=self._channel_id)
+        if not self._channel_id and self._pairing_code:
+            logger.warning(
+                "Discord bridge not configured with a control channel. Run !setup <code> in the desired channel.",
+                code=self._pairing_code,
+            )
+        elif self._pairing_required and self._pairing_code:
+            logger.warning(
+                "Discord pairing enabled. DM the bot: !pair <code>",
+                code=self._pairing_code,
+            )
+
+    def _session_for_thread(self, thread_id: int) -> str | None:
+        session_id = super()._session_for_thread(thread_id)
+        if session_id:
+            return session_id
+        self._restore_thread_mappings_from_store()
+        return super()._session_for_thread(thread_id)
+
+    async def create_thread(self, session_id: str, session_name: str) -> dict:
+        if not self._client:
+            raise RuntimeError("Discord client not initialized")
+
+        channel = await self._ensure_control_channel()
+        if not channel:
+            raise RuntimeError(f"Discord channel {self._channel_id} not found")
+
+        if hasattr(channel, "send"):
+            return await self._create_public_thread_from_message(
+                session_id=session_id,
+                session_name=session_name,
+                channel=channel,
+            )
+
+        logger.info(
+            "Falling back to upstream Discord thread creation",
+            session_id=session_id,
+            channel_id=self._channel_id,
+        )
+        return await super().create_thread(session_id, session_name)
+
+    def _persist_control_channel(self) -> None:
+        self._ensure_pairing_state_loaded()
+        if self._pairing_state is None:
+            return
+        self._pairing_state.control_channel_id = int(self._channel_id)
+        self._pairing_state.paired_user_ids = set(self._paired_user_ids)
+        save_pairing_state(path=self._pairing_state_path, state=self._pairing_state)
+
+    def _apply_auto_pair_users(self) -> None:
+        if not self._auto_pair_user_ids:
+            return
+        self._ensure_pairing_state_loaded()
+        if self._pairing_state is None:
+            return
+        before = set(self._paired_user_ids)
+        self._paired_user_ids.update(self._auto_pair_user_ids)
+        if self._paired_user_ids == before:
+            return
+        self._pairing_state.paired_user_ids = set(self._paired_user_ids)
+        save_pairing_state(path=self._pairing_state_path, state=self._pairing_state)
+        logger.info(
+            "Auto-paired Discord users from configuration",
+            auto_pair_count=len(self._auto_pair_user_ids),
+        )
+
+    async def _resolve_bootstrap_guild(self) -> Any | None:
+        if not self._client:
+            return None
+
+        guilds = list(getattr(self._client, "guilds", []) or [])
+        if self._guild_id:
+            guild = self._client.get_guild(self._guild_id)
+            if guild is None:
+                logger.warning(
+                    "Configured Discord guild not found for control channel bootstrap",
+                    guild_id=self._guild_id,
+                    guild_count=len(guilds),
+                )
+            return guild
+
+        if len(guilds) == 1:
+            return guilds[0]
+
+        if len(guilds) > 1:
+            logger.warning(
+                "Discord control channel bootstrap needs DISCORD_GUILD_ID when the bot is in multiple guilds",
+                guild_count=len(guilds),
+            )
+            return None
+
+        logger.warning("Discord control channel bootstrap found no accessible guilds")
+        return None
+
+    async def _ensure_control_channel(self) -> Any | None:
+        if not self._client:
+            return None
+
+        if self._channel_id:
+            channel = self._client.get_channel(self._channel_id)
+            if channel is not None:
+                return channel
+            fetch_channel = getattr(self._client, "fetch_channel", None)
+            if fetch_channel is not None:
+                try:
+                    channel = await fetch_channel(self._channel_id)
+                except Exception:
+                    logger.warning(
+                        "Configured Discord control channel is not accessible; retrying bootstrap",
+                        channel_id=self._channel_id,
+                    )
+                else:
+                    return channel
+
+        guild = await self._resolve_bootstrap_guild()
+        if guild is None:
+            return None
+
+        for channel in getattr(guild, "text_channels", []) or []:
+            if getattr(channel, "name", None) != self._control_channel_name:
+                continue
+            self._channel_id = int(channel.id)
+            self._persist_control_channel()
+            logger.info(
+                "Using existing Discord control channel",
+                guild_id=getattr(guild, "id", 0),
+                channel_id=self._channel_id,
+                channel_name=self._control_channel_name,
+            )
+            return channel
+
+        topic = (
+            f"Tether control channel for {socket.gethostname().split('.', 1)[0]}. "
+            "Session threads are created from here automatically."
+        )
+        channel = await guild.create_text_channel(
+            name=self._control_channel_name,
+            topic=topic[:1024],
+        )
+        self._channel_id = int(channel.id)
+        self._persist_control_channel()
+        logger.info(
+            "Created Discord control channel",
+            guild_id=getattr(guild, "id", 0),
+            channel_id=self._channel_id,
+            channel_name=self._control_channel_name,
+        )
+        return channel
+
+    async def _create_public_thread_from_message(
+        self,
+        *,
+        session_id: str,
+        session_name: str,
+        channel: Any,
+    ) -> dict:
+        try:
+            self._reserve_thread_name(session_id, session_name)
+
+            starter_text = (
+                f"🧵 Tether session: **{session_name[:80]}**\n"
+                "This starter message keeps the thread visible in this machine channel."
+            )
+            starter_message = await channel.send(
+                starter_text[:_DISCORD_STARTER_TEXT_LIMIT]
+            )
+            thread = await starter_message.create_thread(
+                name=session_name[:_DISCORD_THREAD_NAME_LIMIT],
+                auto_archive_duration=_DISCORD_AUTO_ARCHIVE_MINUTES,
+            )
+
+            thread_id = thread.id
+            self._thread_ids[session_id] = thread_id
+            try:
+                await thread.send(
+                    "Tether session thread.\n"
+                    "Send a message here to provide input. Use `!stop` to interrupt, `!usage` for token usage."
+                )
+            except Exception:
+                pass
+
+            logger.info(
+                "Created visible Discord thread",
+                session_id=session_id,
+                thread_id=thread_id,
+                name=session_name,
+                channel_id=self._channel_id,
+            )
+            return {
+                "thread_id": str(thread_id),
+                "platform": "discord",
+            }
+        except Exception as exc:
+            logger.exception(
+                "Failed to create visible Discord thread", session_id=session_id
+            )
+            if self._thread_names.get(session_id) == session_name:
+                self._release_thread_name(session_id)
+            raise RuntimeError(f"Failed to create Discord thread: {exc}") from exc

--- a/agent/tether/bridges/reaction_shortcuts.py
+++ b/agent/tether/bridges/reaction_shortcuts.py
@@ -1,0 +1,73 @@
+"""Shared helpers for reaction-driven session creation shortcuts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_CHECKMARK_CANONICAL = "white_check_mark"
+_CHECKMARK_ALIASES = {
+    "✅": _CHECKMARK_CANONICAL,
+    "checkmark": _CHECKMARK_CANONICAL,
+    "heavy_check_mark": _CHECKMARK_CANONICAL,
+    "white_check_mark": _CHECKMARK_CANONICAL,
+    "white-heavy-check-mark": _CHECKMARK_CANONICAL,
+}
+
+
+@dataclass(frozen=True)
+class ReactionShortcutRequest:
+    """Parsed ``!new`` reaction shortcut payload."""
+
+    args: str
+    prompt: str
+
+
+class ReactionShortcutError(ValueError):
+    """User-facing validation error for the reaction shortcut."""
+
+
+def canonical_reaction_name(raw: str) -> str:
+    """Normalize a reaction token for Slack and Discord matching."""
+    token = (raw or "").strip()
+    if not token:
+        return ""
+    token = token.strip(":")
+    return _CHECKMARK_ALIASES.get(token, token.casefold())
+
+
+def reaction_matches(configured_reaction: str, actual_reaction: str) -> bool:
+    """Return True when the configured shortcut reaction matches the incoming one."""
+    return canonical_reaction_name(configured_reaction) == canonical_reaction_name(
+        actual_reaction
+    )
+
+
+def parse_reaction_shortcut_message(text: str) -> ReactionShortcutRequest | None:
+    """Parse a top-level control-channel message for the reaction shortcut.
+
+    Returns ``None`` when the message is not a shortcut candidate. Raises
+    ``ReactionShortcutError`` when the message opts in via ``!new`` but does not
+    provide the required prompt body.
+    """
+    normalized = (text or "").strip()
+    if not normalized:
+        return None
+
+    lines = normalized.splitlines()
+    header = lines[0].strip()
+    if not header.lower().startswith("!new"):
+        return None
+
+    args = header[4:].strip()
+    if not args:
+        raise ReactionShortcutError(
+            "First line must use `!new <agent> <directory>` or `!new <directory>`."
+        )
+
+    prompt = "\n".join(line.rstrip() for line in lines[1:]).strip()
+    if not prompt:
+        raise ReactionShortcutError(
+            "Add a prompt below the `!new ...` line before reacting."
+        )
+
+    return ReactionShortcutRequest(args=args, prompt=prompt)

--- a/agent/tether/bridges/slack/bot.py
+++ b/agent/tether/bridges/slack/bot.py
@@ -1,3 +1,222 @@
-"""Compatibility shim: re-exports from agent_tether.slack.bot."""
-# ruff: noqa: F401
-from agent_tether.slack.bot import SlackBridge
+"""Tether-local Slack bridge compatibility wrapper."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import structlog
+from agent_tether.slack.bot import SlackBridge as UpstreamSlackBridge
+from agent_tether.thread_naming import adapter_to_runner
+
+from tether.bridges.reaction_shortcuts import (
+    ReactionShortcutError,
+    parse_reaction_shortcut_message,
+    reaction_matches,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class SlackBridge(UpstreamSlackBridge):
+    """Local Slack wrapper that adds reaction-driven session creation."""
+
+    def __init__(
+        self,
+        bot_token: str,
+        channel_id: str,
+        slack_app_token: str | None = None,
+        config=None,
+        callbacks=None,
+        get_session_directory=None,
+        get_session_info=None,
+        on_session_bound=None,
+        *,
+        reaction_new_session_enabled: bool = True,
+        reaction_new_session_emoji: str = "✅",
+    ) -> None:
+        super().__init__(
+            bot_token=bot_token,
+            channel_id=channel_id,
+            slack_app_token=slack_app_token,
+            config=config,
+            callbacks=callbacks,
+            get_session_directory=get_session_directory,
+            get_session_info=get_session_info,
+            on_session_bound=on_session_bound,
+        )
+        self._reaction_new_session_enabled = reaction_new_session_enabled
+        self._reaction_new_session_emoji = reaction_new_session_emoji or "✅"
+        self._reaction_shortcuts_completed: set[str] = set()
+        self._reaction_shortcuts_in_progress: set[str] = set()
+
+    async def start(self) -> None:
+        """Initialize Slack client and socket mode."""
+        try:
+            from slack_bolt.adapter.socket_mode.async_handler import (
+                AsyncSocketModeHandler,
+            )
+            from slack_bolt.async_app import AsyncApp
+            from slack_sdk.web.async_client import AsyncWebClient
+        except ImportError:
+            logger.error(
+                "slack_sdk or slack_bolt not installed. Install with: pip install slack-sdk slack-bolt"
+            )
+            return
+
+        self._client = AsyncWebClient(token=self._bot_token)
+
+        app_token = self._slack_app_token
+        if app_token:
+            try:
+                self._app = AsyncApp(token=self._bot_token)
+
+                @self._app.event("message")
+                async def handle_message(event: dict, say: Any) -> None:
+                    await self._handle_message(event)
+
+                @self._app.event("reaction_added")
+                async def handle_reaction(event: dict, say: Any) -> None:
+                    await self._handle_reaction_added(event)
+
+                handler = AsyncSocketModeHandler(self._app, app_token)
+                asyncio.create_task(handler.start_async())
+
+                logger.info(
+                    "Slack bridge initialized with socket mode",
+                    channel_id=self._channel_id,
+                    reaction_shortcuts=self._reaction_new_session_enabled,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to initialize Slack socket mode, falling back to basic mode"
+                )
+                logger.info(
+                    "Slack bridge initialized (basic mode, no input forwarding)",
+                    channel_id=self._channel_id,
+                )
+        else:
+            logger.info(
+                "Slack bridge initialized (basic mode — set SLACK_APP_TOKEN for commands and input)",
+                channel_id=self._channel_id,
+            )
+
+    def _begin_reaction_shortcut(self, source_message_id: str) -> bool:
+        if source_message_id in self._reaction_shortcuts_completed:
+            return False
+        if source_message_id in self._reaction_shortcuts_in_progress:
+            return False
+        self._reaction_shortcuts_in_progress.add(source_message_id)
+        return True
+
+    def _finish_reaction_shortcut(
+        self, source_message_id: str, *, persist: bool
+    ) -> None:
+        self._reaction_shortcuts_in_progress.discard(source_message_id)
+        if persist:
+            self._reaction_shortcuts_completed.add(source_message_id)
+
+    @staticmethod
+    def _is_top_level_source_message(message: dict) -> bool:
+        thread_ts = str(message.get("thread_ts") or "").strip()
+        ts = str(message.get("ts") or "").strip()
+        return not thread_ts or thread_ts == ts
+
+    async def _handle_reaction_added(self, event: dict) -> None:
+        """Create and start a new session from a reacted control-channel message."""
+        if not self._reaction_new_session_enabled or not self._client:
+            return
+
+        item = event.get("item")
+        if not isinstance(item, dict):
+            return
+
+        channel_id = str(item.get("channel") or "").strip()
+        source_message_id = str(item.get("ts") or "").strip()
+        if not channel_id or channel_id != self._channel_id:
+            return
+        if not source_message_id:
+            return
+        if not reaction_matches(
+            self._reaction_new_session_emoji,
+            str(event.get("reaction") or ""),
+        ):
+            return
+        if not self._begin_reaction_shortcut(source_message_id):
+            return
+
+        persist = False
+        reply_event = {"channel": channel_id, "ts": source_message_id}
+        try:
+            response = await self._client.conversations_history(
+                channel=channel_id,
+                latest=source_message_id,
+                inclusive=True,
+                limit=1,
+            )
+            if not response.get("ok"):
+                raise RuntimeError("Slack could not load the reacted message")
+
+            messages = response.get("messages") or []
+            if not messages:
+                return
+
+            message = messages[0]
+            if message.get("bot_id") or message.get("subtype") == "bot_message":
+                return
+            if not self._is_top_level_source_message(message):
+                return
+
+            shortcut = parse_reaction_shortcut_message(str(message.get("text") or ""))
+            if shortcut is None:
+                return
+
+            adapter, directory = await self._parse_new_args(
+                shortcut.args,
+                base_session_id=None,
+            )
+            dir_short = directory.rstrip("/").rsplit("/", 1)[-1] or "Session"
+            agent_label = (
+                self._adapter_label(adapter)
+                or self._adapter_label(self._config.default_adapter)
+                or "Claude"
+            )
+            runner_type = adapter_to_runner(adapter or self._config.default_adapter)
+            session_name = self._make_external_thread_name(
+                directory=directory,
+                session_id="",
+                runner_type=runner_type,
+            )
+
+            session = await self._create_session_via_api(
+                directory=directory,
+                platform="slack",
+                adapter=adapter,
+                session_name=session_name,
+            )
+            session_id = str(session.get("id") or "").strip()
+            if not session_id:
+                raise RuntimeError("Tether did not return a session id")
+
+            persist = True
+            await self._send_input_or_start_via_api(
+                session_id=session_id,
+                text=shortcut.prompt,
+            )
+            await self._reply(
+                reply_event,
+                f"✅ New {agent_label} session created in {dir_short} from a checkmark reaction.",
+            )
+        except (ReactionShortcutError, ValueError) as exc:
+            await self._reply(reply_event, str(exc))
+        except Exception as exc:
+            logger.exception(
+                "Failed to create Slack session from reaction",
+                source_message_id=source_message_id,
+            )
+            await self._reply(
+                reply_event,
+                f"Failed to create session from reaction: {exc}",
+            )
+        finally:
+            self._finish_reaction_shortcut(source_message_id, persist=persist)

--- a/agent/tether/main.py
+++ b/agent/tether/main.py
@@ -117,12 +117,14 @@ async def _init_bridges() -> None:
     slack_channel = settings.slack_channel_id()
     if slack_token and slack_channel:
         try:
-            from agent_tether import SlackBridge
+            from tether.bridges.slack.bot import SlackBridge
 
             bridge = SlackBridge(
                 bot_token=slack_token,
                 channel_id=slack_channel,
                 slack_app_token=settings.slack_app_token(),
+                reaction_new_session_enabled=settings.bridge_reaction_new_session_enabled(),
+                reaction_new_session_emoji=settings.bridge_reaction_new_session_emoji(),
                 config=config,
                 callbacks=callbacks,
                 get_session_directory=get_session_directory,
@@ -152,6 +154,8 @@ async def _init_bridges() -> None:
                     auto_pair_user_ids=settings.discord_auto_pair_user_ids(),
                     pairing_code=settings.discord_pairing_code(),
                     guild_id=settings.discord_guild_id(),
+                    reaction_new_session_enabled=settings.bridge_reaction_new_session_enabled(),
+                    reaction_new_session_emoji=settings.bridge_reaction_new_session_emoji(),
                 ),
                 config=config,
                 callbacks=callbacks,

--- a/agent/tether/main.py
+++ b/agent/tether/main.py
@@ -141,8 +141,7 @@ async def _init_bridges() -> None:
     discord_channel = settings.discord_channel_id()
     if discord_token:
         try:
-            from agent_tether import DiscordBridge
-            from agent_tether.discord.bot import DiscordConfig
+            from tether.bridges.discord.bot import DiscordBridge, DiscordConfig
 
             bridge = DiscordBridge(
                 bot_token=discord_token,
@@ -150,7 +149,9 @@ async def _init_bridges() -> None:
                 discord_config=DiscordConfig(
                     require_pairing=settings.discord_require_pairing(),
                     allowed_user_ids=settings.discord_allowed_user_ids(),
+                    auto_pair_user_ids=settings.discord_auto_pair_user_ids(),
                     pairing_code=settings.discord_pairing_code(),
+                    guild_id=settings.discord_guild_id(),
                 ),
                 config=config,
                 callbacks=callbacks,
@@ -162,11 +163,19 @@ async def _init_bridges() -> None:
             bridge.restore_thread_mappings(sessions)
             bridge_manager.register_bridge("discord", bridge)
             if not discord_channel:
-                pairing_code = settings.discord_pairing_code() or bridge._pairing_code
-                logger.info(
-                    "Discord bridge started. Run !setup in your Discord channel to configure it.",
-                    code=pairing_code,
-                )
+                guild_id = settings.discord_guild_id()
+                if guild_id:
+                    logger.info(
+                        "Discord bridge started. The control channel will be auto-created or reused after the bot connects.",
+                        guild_id=guild_id,
+                        channel_name=bridge._control_channel_name,
+                    )
+                else:
+                    pairing_code = settings.discord_pairing_code() or bridge._pairing_code
+                    logger.info(
+                        "Discord bridge started. Run !setup in your Discord channel to configure it.",
+                        code=pairing_code,
+                    )
             else:
                 logger.info("Discord bridge registered and started")
         except Exception:

--- a/agent/tether/settings.py
+++ b/agent/tether/settings.py
@@ -40,6 +40,23 @@ def _get_int(name: str, default: int = 0) -> int:
         return default
 
 
+def _get_int_set(name: str) -> set[int]:
+    """Parse a comma-separated list of integer IDs."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return set()
+    out: set[int] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.add(int(part))
+        except ValueError:
+            continue
+    return out
+
+
 class Settings:
     """Centralized settings for the Tether agent.
 
@@ -389,6 +406,20 @@ class Settings:
             return 0
 
     @staticmethod
+    def discord_guild_id() -> int:
+        """Discord guild ID used for automatic control-channel bootstrap.
+
+        Env: DISCORD_GUILD_ID
+        """
+        value = os.environ.get("DISCORD_GUILD_ID", "").strip()
+        if not value:
+            return 0
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+
+    @staticmethod
     def discord_require_pairing() -> bool:
         """Require Discord users to pair before using the bot.
 
@@ -416,19 +447,15 @@ class Settings:
 
         Env: DISCORD_ALLOWED_USER_IDS (e.g. "123,456")
         """
-        raw = os.environ.get("DISCORD_ALLOWED_USER_IDS", "").strip()
-        if not raw:
-            return set()
-        out: set[int] = set()
-        for part in raw.split(","):
-            part = part.strip()
-            if not part:
-                continue
-            try:
-                out.add(int(part))
-            except ValueError:
-                continue
-        return out
+        return _get_int_set("DISCORD_ALLOWED_USER_IDS")
+
+    @staticmethod
+    def discord_auto_pair_user_ids() -> set[int]:
+        """Comma-separated Discord user IDs to pre-authorize as paired.
+
+        Env: DISCORD_AUTO_PAIR_USER_IDS (e.g. "123,456")
+        """
+        return _get_int_set("DISCORD_AUTO_PAIR_USER_IDS")
 
 
 # Singleton instance for convenient imports

--- a/agent/tether/settings.py
+++ b/agent/tether/settings.py
@@ -207,6 +207,26 @@ class Settings:
         return _get_int("TETHER_AGENT_BRIDGE_ERROR_DEBOUNCE_SECONDS", default=30)
 
     @staticmethod
+    def bridge_reaction_new_session_enabled() -> bool:
+        """Enable the `!new` plus checkmark reaction shortcut in Slack/Discord.
+
+        When enabled, a top-level control-channel message whose first line starts
+        with ``!new`` can create and start a new session when reacted to with the
+        configured emoji.
+
+        Env: TETHER_BRIDGE_REACTION_NEW_SESSION_ENABLED (default: 1)
+        """
+        return _get_bool("TETHER_BRIDGE_REACTION_NEW_SESSION_ENABLED", default=True)
+
+    @staticmethod
+    def bridge_reaction_new_session_emoji() -> str:
+        """Emoji or reaction name used to trigger the new-session shortcut.
+
+        Env: TETHER_BRIDGE_REACTION_NEW_SESSION_EMOJI (default: ✅)
+        """
+        return _get("TETHER_BRIDGE_REACTION_NEW_SESSION_EMOJI", default="✅")
+
+    @staticmethod
     def turn_timeout_seconds() -> int:
         """Maximum seconds for a runner turn before timeout. 0 disables.
 

--- a/docs/BRIDGES.md
+++ b/docs/BRIDGES.md
@@ -70,6 +70,7 @@ Routes store events to bridge methods:
 - Auto-approve sends `✅ **Tool** — auto-approved (reason)` notification
 - Optional pairing/allowlist: when enabled, only authorized Discord user IDs can run commands or send input
 - Optional no-ID setup: if `DISCORD_CHANNEL_ID` is unset, run `!setup <code>` in the desired channel to configure it
+- Optional guild bootstrap: if `DISCORD_GUILD_ID` is set and `DISCORD_CHANNEL_ID` is unset, Tether will create or reuse a host-named control channel such as `🤖-kali14`
 
 ## Auto-Approve System
 
@@ -90,9 +91,11 @@ Stored in base class as in-memory dicts:
 | `SLACK_CHANNEL_ID` | Slack channel ID |
 | `DISCORD_BOT_TOKEN` | Discord bot token |
 | `DISCORD_CHANNEL_ID` | Discord channel ID (int) |
+| `DISCORD_GUILD_ID` | Discord guild/server ID used for automatic control-channel creation |
 | `DISCORD_REQUIRE_PAIRING` | Require pairing before using the Discord bot (0/1) |
 | `DISCORD_PAIRING_CODE` | Optional fixed pairing code (if unset and pairing is required, one is generated and logged) |
 | `DISCORD_ALLOWED_USER_IDS` | Comma-separated Discord user IDs that are always authorized |
+| `DISCORD_AUTO_PAIR_USER_IDS` | Comma-separated Discord user IDs to seed into the paired-user set at launch |
 
 Bridges auto-initialize in `main.py` lifespan if tokens are configured.
 

--- a/docs/BRIDGES.md
+++ b/docs/BRIDGES.md
@@ -62,12 +62,14 @@ Routes store events to bridge methods:
 - Socket mode for real-time events (requires `SLACK_APP_TOKEN`)
 - Text-based approval: reply `allow`, `deny`, `allow all`, `allow {tool}`
 - Auto-approve sends `✅ *Tool* — auto-approved (reason)` notification
+- Optional reaction shortcut: react with `✅` to a top-level control-channel message whose first line starts with `!new ...` and whose remaining body is the initial prompt
 
 ### Discord (`agent/tether/bridges/discord/`)
 - **bot.py** — Thread-based: same `!` commands as Slack
 - discord.py client with message_content intent
 - Text-based approval: same as Slack
 - Auto-approve sends `✅ **Tool** — auto-approved (reason)` notification
+- Optional reaction shortcut: react with `✅` to a top-level control-channel message whose first line starts with `!new ...` and whose remaining body is the initial prompt
 - Optional pairing/allowlist: when enabled, only authorized Discord user IDs can run commands or send input
 - Optional no-ID setup: if `DISCORD_CHANNEL_ID` is unset, run `!setup <code>` in the desired channel to configure it
 - Optional guild bootstrap: if `DISCORD_GUILD_ID` is set and `DISCORD_CHANNEL_ID` is unset, Tether will create or reuse a host-named control channel such as `🤖-kali14`
@@ -95,6 +97,8 @@ Stored in base class as in-memory dicts:
 | `DISCORD_REQUIRE_PAIRING` | Require pairing before using the Discord bot (0/1) |
 | `DISCORD_PAIRING_CODE` | Optional fixed pairing code (if unset and pairing is required, one is generated and logged) |
 | `DISCORD_ALLOWED_USER_IDS` | Comma-separated Discord user IDs that are always authorized |
+| `TETHER_BRIDGE_REACTION_NEW_SESSION_ENABLED` | Enable the `!new` plus checkmark reaction shortcut in Slack and Discord (default `1`) |
+| `TETHER_BRIDGE_REACTION_NEW_SESSION_EMOJI` | Emoji or reaction name used for the new-session shortcut (default `✅`) |
 | `DISCORD_AUTO_PAIR_USER_IDS` | Comma-separated Discord user IDs to seed into the paired-user set at launch |
 
 Bridges auto-initialize in `main.py` lifespan if tokens are configured.


### PR DESCRIPTION
## Summary

- add a shared reaction-shortcut parser so Slack and Discord normalize checkmark reactions the same way
- allow authorized users to react with `✅` to a top-level control-channel `!new ...` message to create and start a new session
- keep the existing `!new` argument contract, reuse adapter/directory parsing, and dedupe duplicate reaction events by source message id
- preserve the Discord public-thread/control-channel behavior from the first PR while adding the reaction entrypoint

## Usage

Post a top-level control-channel message:

```text
!new codex /worktrees/tether
Fix the failing Discord tests and keep the control channel bootstrap intact.
```

Then react to that message with `✅`.

## Review Notes

- Depends on #6 for the Discord bridge wrapper.
- Incremental compare: https://github.com/Adminrealagi/tether/compare/codex/upstream-discord-bridge-improvements...codex/upstream-reaction-session-shortcuts

## Validation

- `uv run --extra dev python -m pytest tests/test_discord_bridge.py tests/test_reaction_shortcut_parser_contract.py tests/test_reaction_shortcuts_planned.py tests/test_slack_bridge.py tests/test_settings.py -q`
